### PR TITLE
Fix int overflows on linux compiling

### DIFF
--- a/kdf/nist_sp800_56a.go
+++ b/kdf/nist_sp800_56a.go
@@ -6,6 +6,10 @@ import (
 	"github.com/dvsekhvalnov/jose2go/arrays"
 )
 
+const (
+	MAX_INT = int(^uint(0)>>1);
+)
+
 // DeriveConcatKDF implements NIST SP 800-56A Concatenation Key Derivation Function. Derives 
 // key material of keydatalen bits size given Z (sharedSecret), OtherInfo (AlgorithmID | 
 // PartyUInfo | PartyVInfo | SuppPubInfo | SuppPrivInfo) and hash function
@@ -17,7 +21,7 @@ func DeriveConcatKDF(keydatalen int, sharedSecret, algId, partyUInfo, partyVInfo
 	
 	reps := int(math.Ceil(float64(keyLenBytes) / float64(h.Size())))
 	
-	if reps > int(^uint(0)>>1) {
+	if reps > MAX_INT {
 		panic("kdf.DeriveConcatKDF: too much iterations (more than 2^32-1).")
 	}
 	

--- a/kdf/nist_sp800_56a.go
+++ b/kdf/nist_sp800_56a.go
@@ -17,7 +17,7 @@ func DeriveConcatKDF(keydatalen int, sharedSecret, algId, partyUInfo, partyVInfo
 	
 	reps := int(math.Ceil(float64(keyLenBytes) / float64(h.Size())))
 	
-	if reps > 4294967295 {
+	if reps > int(^uint(0)>>1) {
 		panic("kdf.DeriveConcatKDF: too much iterations (more than 2^32-1).")
 	}
 	

--- a/kdf/nist_sp800_56a.go
+++ b/kdf/nist_sp800_56a.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	MAX_INT = int(^uint(0)>>1);
+	MaxInt = int(^uint(0)>>1);
 )
 
 // DeriveConcatKDF implements NIST SP 800-56A Concatenation Key Derivation Function. Derives 
@@ -21,7 +21,7 @@ func DeriveConcatKDF(keydatalen int, sharedSecret, algId, partyUInfo, partyVInfo
 	
 	reps := int(math.Ceil(float64(keyLenBytes) / float64(h.Size())))
 	
-	if reps > MAX_INT {
+	if reps > MaxInt {
 		panic("kdf.DeriveConcatKDF: too much iterations (more than 2^32-1).")
 	}
 	

--- a/kdf/pbkdf2.go
+++ b/kdf/pbkdf2.go
@@ -20,7 +20,7 @@ func DerivePBKDF2(password, salt []byte, iterationCount, keyBitLength int, h has
 	r := dkLen - (l-1)*hLen
 
 	// 1. If dkLen > (2^32 - 1) * hLen, output "derived key too long" and stop.
-	if dkLen > int(^uint(0)>>1) {
+	if dkLen > MAX_INT {
 		panic(fmt.Sprintf("kdf.DerivePBKDF2: expects derived key size to be not more that (2^32-1) bits, but was requested %v bits.", keyBitLength))
 	}
 

--- a/kdf/pbkdf2.go
+++ b/kdf/pbkdf2.go
@@ -20,7 +20,7 @@ func DerivePBKDF2(password, salt []byte, iterationCount, keyBitLength int, h has
 	r := dkLen - (l-1)*hLen
 
 	// 1. If dkLen > (2^32 - 1) * hLen, output "derived key too long" and stop.
-	if dkLen > MAX_INT {
+	if dkLen > MaxInt {
 		panic(fmt.Sprintf("kdf.DerivePBKDF2: expects derived key size to be not more that (2^32-1) bits, but was requested %v bits.", keyBitLength))
 	}
 

--- a/kdf/pbkdf2.go
+++ b/kdf/pbkdf2.go
@@ -20,7 +20,7 @@ func DerivePBKDF2(password, salt []byte, iterationCount, keyBitLength int, h has
 	r := dkLen - (l-1)*hLen
 
 	// 1. If dkLen > (2^32 - 1) * hLen, output "derived key too long" and stop.
-	if dkLen > 4294967295 {
+	if dkLen > int(^uint(0)>>1) {
 		panic(fmt.Sprintf("kdf.DerivePBKDF2: expects derived key size to be not more that (2^32-1) bits, but was requested %v bits.", keyBitLength))
 	}
 


### PR DESCRIPTION
GOOS=linux GOARCH=386 CGO_ENABLED=0 go build *.go;
# github.com/dvsekhvalnov/jose2go/kdf
../../../github.com/dvsekhvalnov/jose2go/kdf/nist_sp800_56a.go:20: constant 4294967295 overflows int
../../../github.com/dvsekhvalnov/jose2go/kdf/pbkdf2.go:23: constant 4294967295 overflows int
make[1]: *** [build] Error 2
make: *** [release] Error 2